### PR TITLE
Revert "Update package.json"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@svelteuidev/composables": "^0.7.3",
-		"@svelteuidev/core": "^0.7.3",
+		"@svelteuidev/composables": "^0.7.1",
+		"@svelteuidev/core": "^0.7.2",
 		"jest": "^28.1.3",
 		"prelude-ts": "^1.0.4",
 		"ramda": "^0.28.0",


### PR DESCRIPTION
This reverts commit 3d252a95051bd508dc056333e9d28a0176b43626 because updated dependencies enforce usage of outdated svelte version